### PR TITLE
Show errors per input in `/eth-unit-conversion`

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -22,7 +22,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <main className="prose mx-auto mt-12 h-full max-w-4xl">
-      <ThemeProvider attribute="class" defaultTheme="light">
+      <ThemeProvider attribute="class" defaultTheme="dark">
         <Navigation handleShowMobileTree={handleShowMobileTree} />
         <div className="mt-6 flex min-h-full max-w-6xl gap-12 rounded-md bg-deth-gray-700 p-12 align-top">
           <ToolTree isShowMobileTree={isShowMobileTree} isMobile={isMobile} />

--- a/pages/eth-unit-conversion.page.tsx
+++ b/pages/eth-unit-conversion.page.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Fragment, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 import CalculatorSvg from '../public/static/svg/calculator';
 import { Input } from '../src/components/lib/Input';

--- a/pages/eth-unit-conversion.page.tsx
+++ b/pages/eth-unit-conversion.page.tsx
@@ -1,55 +1,70 @@
 import { ChangeEvent, Fragment, useState } from 'react';
 
 import CalculatorSvg from '../public/static/svg/calculator';
+import { Input } from '../src/components/lib/Input';
 import { ToolLayout } from '../src/layout/ToolLayout';
 import { UnitType } from '../src/lib/convertProperties';
 import { convertEthUnits } from '../src/lib/convertUnits';
 import { decodeHex } from '../src/lib/decodeHex';
 import { unitSchema } from '../src/misc/unitSchema';
 
-type State = { wei: string; gwei: string; eth: string };
+type EthUnitConversionState = Record<
+  UnitType,
+  { value: string; error?: string }
+>;
+
+const powers = {
+  wei: -18,
+  gwei: -9,
+  eth: -1,
+};
+
+const initialState: EthUnitConversionState = {
+  wei: { value: '' },
+  gwei: { value: '' },
+  eth: { value: '' },
+};
 
 export default function EthUnitConversion() {
-  const [error, setError] = useState<string | undefined>();
-  const [state, setState] = useState<State>({ wei: '', gwei: '', eth: '' });
+  const [state, setState] = useState<EthUnitConversionState>(initialState);
 
-  const units: UnitTypeExtended[] = [
-    { name: 'wei', powFormat: '10-18', value: state.wei },
-    { name: 'gwei', powFormat: '10-9', value: state.gwei },
-    { name: 'eth', powFormat: '10-1', value: state.eth },
-  ];
+  function handleChangeValue(newValue: string, currentType: UnitType) {
+    newValue = decodeHex(newValue);
 
-  function handleChangeValue(value: string, currentType: UnitType) {
-    value = decodeHex(value);
+    const parsed = unitSchema.safeParse(newValue);
 
-    const result = unitSchema.safeParse(value);
-    if (!result.success) {
-      setError(result.error.errors[0].message);
-    } else {
-      value = result.data;
-      setError(undefined);
+    if (!parsed.success) {
+      setState((prevState) => ({
+        ...prevState,
+        [currentType]: {
+          value: newValue,
+          error: parsed.error.errors[0].message,
+        },
+      }));
+
+      return;
     }
 
-    setState((s) => ({ ...s, [currentType]: value }));
+    newValue = parsed.data;
 
-    for (const unit of units) {
-      if (unit.name === currentType) continue;
+    setState((oldState) => {
+      const newState = { ...oldState };
 
-      let out: string = '';
-      if (parseFloat(value) >= 0) {
-        out = convertEthUnits(value, currentType, unit.name)!;
+      for (const unit of UnitType.values) {
+        if (unit === currentType) newState[unit] = { value: newValue };
+        else if (parseFloat(newValue) >= 0) {
+          const out = convertEthUnits(newValue, currentType, unit)!;
+          if (!isNaN(parseInt(out))) newState[unit] = { value: out };
+        }
       }
-      if (isNaN(parseInt(out))) {
-        out = unit.value;
-      }
 
-      setState((s) => ({ ...s, [unit.name]: out }));
-    }
+      return newState;
+    });
   }
 
   return (
     <ToolLayout>
-      <form className="mx-auto flex flex-col items-start sm:items-center md:items-start">
+      <form className="flex flex-col items-start sm:mx-4 sm:items-center  md:mx-16 md:items-start">
         <header className="mb-6 flex items-center gap-3 align-middle">
           <CalculatorSvg
             width={32}
@@ -63,68 +78,52 @@ export default function EthUnitConversion() {
             Eth unit conversion
           </h3>
         </header>
-        <UnitElements
-          onChange={handleChangeValue}
-          units={units}
-          error={error}
-        />
+        <section className="flex w-full flex-col gap-5">
+          {UnitType.values.map((unit) => (
+            <ConversionInput
+              key={unit}
+              name={unit}
+              {...state[unit]}
+              onChange={handleChangeValue}
+            />
+          ))}
+        </section>
       </form>
     </ToolLayout>
   );
 }
 
-interface UnitElementsProps {
-  units: UnitTypeExtended[];
-  error: string | undefined;
-  onChange: (value: string, unitType: UnitType) => void;
+interface ConversionInputProps {
+  name: UnitType;
+  value: string;
+  error?: string;
+  onChange: (newValue: string, unit: UnitType) => void;
 }
-function UnitElements({
-  units,
+function ConversionInput({
+  name,
+  value,
   error,
   onChange,
-}: UnitElementsProps): JSX.Element {
+}: ConversionInputProps) {
   return (
-    <Fragment>
-      <p
-        data-testid="error"
-        className="absolute top-2/3 text-sm text-deth-error"
-      >
-        {error}
-      </p>
+    <label htmlFor={name} className="flex flex-col">
+      <div className="mb-2 flex gap-2 py-1 text-left text-xs font-medium uppercase tracking-wider">
+        <span>{name}</span>
+        <p className="text-deth-gray-300">
+          10<sup>{powers[name]}</sup>
+        </p>
+      </div>
 
-      {units.map((unit) => {
-        const { name, value, powFormat } = unit;
-        return (
-          <div key={name} className="mt-5 w-full">
-            <section className="flex flex-col">
-              <div className="mb-2 flex gap-2 py-1 text-left text-xs font-medium uppercase tracking-wider">
-                <label htmlFor={name}>{name}</label>
-                <p className="text-deth-gray-300">
-                  {powFormat.slice(0, 2)}
-                  <sup>{powFormat.slice(2, 5)}</sup>
-                </p>
-              </div>
-
-              <input
-                id={name}
-                placeholder={value ? value.toString() : '0'}
-                value={value}
-                type="string"
-                onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                  onChange(event.target.value, name);
-                }}
-                className="rounded-md border border-deth-gray-600 bg-deth-gray-900 p-3 text-lg"
-              />
-            </section>
-          </div>
-        );
-      })}
-    </Fragment>
+      <Input
+        id={name}
+        type="text"
+        placeholder={value ? value.toString() : '0'}
+        value={value}
+        error={error}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          onChange(event.target.value, name);
+        }}
+      />
+    </label>
   );
-}
-
-interface UnitTypeExtended {
-  name: UnitType;
-  powFormat: string;
-  value: string;
 }

--- a/pages/eth-unit-conversion.test.tsx
+++ b/pages/eth-unit-conversion.test.tsx
@@ -7,7 +7,7 @@ describe(EthUnitConversion.name, () => {
   it('sets wei field and gets a correct value in the rest of fields', async () => {
     const root = render(<EthUnitConversion />);
 
-    const weiField = (await root.findByLabelText('wei')) as HTMLInputElement;
+    const weiField = (await root.findByLabelText(/^wei/)) as HTMLInputElement;
 
     fireEvent.change(weiField, {
       target: { value: '10000000001000002333343' },
@@ -15,8 +15,8 @@ describe(EthUnitConversion.name, () => {
 
     expect(weiField.value).toEqual('10000000001000002333343');
 
-    const gweiField = (await root.findByLabelText('gwei')) as HTMLInputElement;
-    const ethField = (await root.findByLabelText('eth')) as HTMLInputElement;
+    const gweiField = (await root.findByLabelText(/gwei/)) as HTMLInputElement;
+    const ethField = (await root.findByLabelText(/eth/)) as HTMLInputElement;
 
     expect(gweiField.value).toEqual('10000000001000.002333343');
     expect(ethField.value).toEqual('10000.000001000002333343');
@@ -25,14 +25,14 @@ describe(EthUnitConversion.name, () => {
   it('sets gwei field and gets a correct value in the rest of fields', async () => {
     const root = render(<EthUnitConversion />);
 
-    const gweiField = (await root.findByLabelText('gwei')) as HTMLInputElement;
+    const gweiField = (await root.findByLabelText(/gwei/)) as HTMLInputElement;
 
     fireEvent.change(gweiField, { target: { value: '14000' } });
 
     expect(gweiField.value).toEqual('14000');
 
-    const weiField = (await root.findByLabelText('wei')) as HTMLInputElement;
-    const ethField = (await root.findByLabelText('eth')) as HTMLInputElement;
+    const weiField = (await root.findByLabelText(/^wei/)) as HTMLInputElement;
+    const ethField = (await root.findByLabelText(/eth/)) as HTMLInputElement;
 
     expect(weiField.value).toEqual('14000000000000');
     expect(ethField.value).toEqual('0.000014');
@@ -41,14 +41,14 @@ describe(EthUnitConversion.name, () => {
   it('sets eth field and gets a correct value in the rest of fields', async () => {
     const root = render(<EthUnitConversion />);
 
-    const ethField = (await root.findByLabelText('eth')) as HTMLInputElement;
+    const ethField = (await root.findByLabelText(/eth/)) as HTMLInputElement;
 
     fireEvent.change(ethField, { target: { value: '0.014' } });
 
     expect(ethField.value).toEqual('0.014');
 
-    const gweiField = (await root.findByLabelText('gwei')) as HTMLInputElement;
-    const weiField = (await root.findByLabelText('wei')) as HTMLInputElement;
+    const gweiField = (await root.findByLabelText(/gwei/)) as HTMLInputElement;
+    const weiField = (await root.findByLabelText(/^wei/)) as HTMLInputElement;
 
     expect(gweiField.value).toEqual('14000000');
     expect(weiField.value).toEqual('14000000000000000');
@@ -56,9 +56,9 @@ describe(EthUnitConversion.name, () => {
 
   it('sets correct gwei input, then adds chars, thus freezes calculation results in other fields', async () => {
     const root = render(<EthUnitConversion />);
-    const gweiField = (await root.findByLabelText('gwei')) as HTMLInputElement;
-    const weiField = (await root.findByLabelText('wei')) as HTMLInputElement;
-    const ethField = (await root.findByLabelText('eth')) as HTMLInputElement;
+    const gweiField = (await root.findByLabelText(/gwei/)) as HTMLInputElement;
+    const weiField = (await root.findByLabelText(/^wei/)) as HTMLInputElement;
+    const ethField = (await root.findByLabelText(/eth/)) as HTMLInputElement;
 
     fireEvent.change(gweiField, { target: { value: '140005.54' } });
     expect(gweiField.value).toEqual('140005.54');
@@ -71,13 +71,13 @@ describe(EthUnitConversion.name, () => {
     expect(ethField.value).toEqual('0.00014000554');
   });
 
-  it('types letters and special signs to one of the fields and error gets displayed', async () => {
+  it('displays error message when user types a special character', async () => {
     const root = render(<EthUnitConversion />);
-    const errorField = await root.findByTestId('error');
-    const gweiField = (await root.findByLabelText('gwei')) as HTMLInputElement;
+    const gweiField = (await root.findByLabelText(/gwei/)) as HTMLInputElement;
 
     fireEvent.change(gweiField, { target: { value: '140fa,@' } });
-    expect(errorField.innerHTML).toEqual(
+
+    expect((await root.findByRole('alert')).innerHTML).toEqual(
       expect.stringMatching(
         "The value mustn't contain letters or any special signs except dot",
       ),
@@ -85,25 +85,27 @@ describe(EthUnitConversion.name, () => {
     expect(gweiField.value).toEqual('140fa,@');
 
     fireEvent.change(gweiField, { target: { value: '' } });
-    expect(errorField.innerHTML).toEqual(
-      expect.stringMatching('The value must be bigger or equal to 1'),
+
+    expect((await root.findByRole('alert')).innerHTML).toEqual(
+      expect.stringMatching('The value must be longer than 1 digit'),
     );
   });
 
   it('types negative number and error gets displayed', async () => {
     const root = render(<EthUnitConversion />);
-    const errorField = await root.findByTestId('error');
-    const weiField = (await root.findByLabelText('wei')) as HTMLInputElement;
-    const gweiField = (await root.findByLabelText('gwei')) as HTMLInputElement;
+    const weiField = (await root.findByLabelText(/^wei/)) as HTMLInputElement;
+    const gweiField = (await root.findByLabelText(/gwei/)) as HTMLInputElement;
 
     fireEvent.change(gweiField, { target: { value: '-12' } });
 
+    expect(gweiField.value).toEqual('-12');
+    expect(weiField.value).toEqual('');
+
+    const errorField = await root.findByRole('alert');
     expect(errorField.innerHTML).toEqual(
       expect.stringMatching(
         "The value mustn't contain letters or any special signs except dot",
       ),
     );
-    expect(gweiField.value).toEqual('-12');
-    expect(weiField.value).toEqual('');
   });
 });

--- a/pages/token-unit-conversion.page.tsx
+++ b/pages/token-unit-conversion.page.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import CalculatorSvg from '../public/static/svg/calculator';
+import { Input } from '../src/components/lib/Input';
 import { ToolLayout } from '../src/layout/ToolLayout';
 import { tokenPrecision } from '../src/lib/convertProperties';
 import { convertTokenUnits } from '../src/lib/convertUnits';
@@ -149,11 +150,11 @@ function UnitElements({
                 <label htmlFor={name}>{name}</label>
               </div>
 
-              <input
+              <Input
                 id={name}
                 placeholder={value ? value.toString() : '0'}
                 value={value}
-                type="string"
+                type="text"
                 onChange={(event) => {
                   onChange(event.target.value, name);
                 }}

--- a/pages/token-unit-conversion.test.tsx
+++ b/pages/token-unit-conversion.test.tsx
@@ -79,7 +79,7 @@ describe(TokenUnitConversion.name, () => {
 
     fireEvent.change(baseField, { target: { value: '' } });
     expect(errorField.innerHTML).toEqual(
-      expect.stringMatching(/The value must be bigger or equal to 1/),
+      expect.stringMatching(/The value must be longer than 1 digit/),
     );
   });
 

--- a/src/components/lib/Input/Input.tsx
+++ b/src/components/lib/Input/Input.tsx
@@ -42,7 +42,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           {...rest}
         />
         <div className="whitespace-normal pt-2">
-          {error && <p className="text-error">{error}</p>}
+          {error && (
+            <p role="alert" aria-atomic="true" className="text-error">
+              {error}
+            </p>
+          )}
         </div>
       </div>
     );

--- a/src/components/lib/Input/Input.tsx
+++ b/src/components/lib/Input/Input.tsx
@@ -1,19 +1,37 @@
 import { ComponentPropsWithoutRef, forwardRef } from 'react';
 
+import { constrain } from '../../../misc/constrain';
+
 export interface InputProps extends ComponentPropsWithoutRef<'input'> {
   error?: string;
 }
 
+/**
+ * Most inputs in the application will serve as numeric value inputs
+ * without need for autocomplete or spellcheck.
+ *
+ * Whenever `autoComplete` prop on `Input` is not set to a value other than
+ * `"off"`, we also use all of the other props below.
+ */
+const autoCompleteProps = constrain<InputProps>()({
+  autoComplete: 'off',
+  autoCorrect: 'off',
+  spellCheck: 'false',
+  // Disable LastPass widget
+  'data-lpignore': 'true',
+});
+
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, error, ...rest }, ref) => {
+  ({ className, error, autoComplete = 'off', ...rest }, ref) => {
     return (
       <div>
         <input
           ref={ref}
           aria-invalid={!!error}
+          {...(autoComplete === 'off' && autoCompleteProps)}
           className={
-            'h-10 w-full rounded-md border border-gray-600 bg-gray-900 text-sm ' +
-            'p-4 text-white focus:outline-none ' +
+            'w-full rounded-md border border-gray-600 bg-gray-900 ' +
+            'p-3.75 text-lg leading-none text-white focus:outline-none ' +
             'invalid:border-error invalid:caret-error ' +
             'disabled:text-white/50 ' +
             (error
@@ -23,7 +41,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           }
           {...rest}
         />
-        <div className="pt-2">
+        <div className="whitespace-normal pt-2">
           {error && <p className="text-error">{error}</p>}
         </div>
       </div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -12,6 +12,10 @@ html {
   @apply bg-gray-900;
 }
 
+*::selection {
+  @apply bg-purple/50;
+}
+
 #__next {
   height: 100vh;
 }

--- a/src/lib/convertProperties.ts
+++ b/src/lib/convertProperties.ts
@@ -8,6 +8,11 @@ export const unitPrecision: PrecisionDict<UnitType> = {
 
 export type UnitType = 'wei' | 'gwei' | 'eth';
 
+const unitTypes: UnitType[] = ['wei', 'gwei', 'eth'];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UnitType = { values: unitTypes };
+
 export const tokenPrecision: PrecisionDict<TokenUnitType> = {
   unit: 1,
   base: 18,

--- a/src/misc/constrain.ts
+++ b/src/misc/constrain.ts
@@ -1,0 +1,12 @@
+/**
+ * Ensures `value` is of a subtype of `Given` while preserving its exact type.
+ *
+ * @example
+ * const numbers = constrain<Record<string, number>>()({ one: 1, two: 2 })
+ *
+ * @see https://kentcdodds.com/blog/how-to-write-a-constrained-identity-function-in-typescript
+ */
+export const constrain =
+  <Given extends unknown>() =>
+  <Inferred extends Given>(value: Inferred) =>
+    value;

--- a/src/misc/unitSchema.ts
+++ b/src/misc/unitSchema.ts
@@ -8,6 +8,6 @@ export const unitSchema = z.preprocess(
       message:
         "The value mustn't contain letters or any special signs except dot",
     })
-    .min(1, { message: 'The value must be bigger or equal to 1' })
-    .max(26, { message: 'The value must be less or equal to 26' }),
+    .min(1, { message: 'The value must be longer than 1 digit' })
+    .max(26, { message: 'The value must be shorter than 26 digits' }),
 );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
     optimizeUniversalDefaults: true,
   },
   content: ['./{pages,src}/**/*.{tx,tsx}'],
+  // We'll always in dark mode until we implement light mode.
+  // We're using `next-themes` which reads the set color mode from local storage
+  // and infers a default from `prefers-color-scheme`.
   darkMode: 'class',
   theme: {
     colors: {
@@ -106,6 +109,9 @@ module.exports = {
           },
         },
       }),
+      spacing: {
+        3.75: '0.9375rem', // We often need (16px (1rem) - 1px) to correct for 1px border.
+      },
     },
   },
   variants: {},


### PR DESCRIPTION
[DET-98](https://linear.app/deth/issue/DET-98/error-handling-per-component)

![image](https://user-images.githubusercontent.com/15332326/161321015-4c92322f-10aa-40db-8bb7-8df3e62e10e7.png)

I had to remove `mx-auto`, because error messages resized the container when they appeared.
I also updated the error message for number length (the picture shows the old one). I'd rather use arbitrary precision numbers in the future though. 