### PR TITLE
Better results display in all of the components

### DIFF
--- a/pages/calldata-decoder.page.tsx
+++ b/pages/calldata-decoder.page.tsx
@@ -172,6 +172,7 @@ export default function CalldataDecoder({
         };
       });
       setDecodeResults(mappedResults);
+      return;
     }
     let decodeResult: DecodeResult | undefined;
     let abi: Interface | Error | undefined;

--- a/pages/calldata-decoder.page.tsx
+++ b/pages/calldata-decoder.page.tsx
@@ -305,16 +305,17 @@ export default function CalldataDecoder({
                   {signatureHash &&
                     decodeResults?.length! > 0 &&
                     hexSchema.safeParse(signatureHash).success && (
-                      <div
-                        className="m-0 flex cursor-pointer items-center gap-2 rounded-md border border-gray-600
-                      py-2 px-3 duration-200 hover:bg-gray-700
-                      hover:shadow-md hover:shadow-pink/25 hover:outline hover:outline-2
-                    active:bg-gray-800"
-                      >
+                      <div className="flex items-center gap-3">
                         <p className="text-purple-400 font-bold">
                           Signature hash
                         </p>
-                        <b>{signatureHash}</b>
+                        <div
+                          className="m-0 flex h-10 cursor-pointer items-center gap-2 rounded-md 
+                          border border-gray-600 py-2 px-3 duration-200 hover:bg-gray-700
+                          hover:outline active:bg-gray-800"
+                        >
+                          <b>{signatureHash}</b>
+                        </div>
                       </div>
                     )}
                 </div>

--- a/pages/constructor-encoder.page.tsx
+++ b/pages/constructor-encoder.page.tsx
@@ -2,10 +2,10 @@ import { Interface } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { isValidAddress, stripHexPrefix } from 'ethereumjs-util';
 import { ChangeEvent, ReactElement, useState } from 'react';
-import { CopyIcon } from '../src/components/icons/CopyIcon';
-import { OkIcon } from '../src/components/icons/OkIcon';
 
+import { CopyIcon } from '../src/components/icons/CopyIcon';
 import { DecodersIcon } from '../src/components/icons/DecodersIcon';
+import { OkIcon } from '../src/components/icons/OkIcon';
 import { Button } from '../src/components/lib/Button';
 import { Input } from '../src/components/lib/Input';
 import { ToolContainer } from '../src/components/ToolContainer';

--- a/pages/constructor-encoder.page.tsx
+++ b/pages/constructor-encoder.page.tsx
@@ -224,7 +224,6 @@ function EncodedBlock({
           setCopyNotification(false);
         }, 1500);
       }}
-      aria-label="encoded-row"
     >
       <p className="text-gray-600">{`[${index}]`}</p>
       <p aria-label="encoded-row" id="node-value">

--- a/pages/constructor-encoder.page.tsx
+++ b/pages/constructor-encoder.page.tsx
@@ -2,6 +2,8 @@ import { Interface } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { isValidAddress, stripHexPrefix } from 'ethereumjs-util';
 import { ChangeEvent, ReactElement, useState } from 'react';
+import { CopyIcon } from '../src/components/icons/CopyIcon';
+import { OkIcon } from '../src/components/icons/OkIcon';
 
 import { DecodersIcon } from '../src/components/icons/DecodersIcon';
 import { Button } from '../src/components/lib/Button';
@@ -132,7 +134,7 @@ export default function ConstructorEncoder(): ReactElement {
           iface.deploy.inputs.map((input, i) => (
             <section className="flex items-center gap-2" key={input.name}>
               <div className="flex flex-1 flex-col">
-                <label className="pb-2" htmlFor={`${input.name}`}>
+                <label htmlFor={`${input.name}`}>
                   <div>
                     <b className="text-purple-600">{input.type}</b>{' '}
                     <b>{input.name}</b>
@@ -145,7 +147,10 @@ export default function ConstructorEncoder(): ReactElement {
                   value={values[i]}
                   error={errors[i]}
                   placeholder="e.g 0x0..."
-                  className="border-deth-gray-600 bg-deth-gray-900 mb-2 mr-auto h-10 w-3/5 rounded-md border text-sm focus:outline-none"
+                  className="w-full rounded-md border
+                  border-gray-600 bg-gray-900 p-3.75 text-lg leading-none 
+                  text-white invalid:border-error invalid:caret-error 
+                  focus:border-pink focus:caret-pink focus:outline-none  disabled:text-white/50"
                   onChange={(event: ChangeEvent<HTMLInputElement>) => {
                     const value = event.target.value;
                     setSingleValue(i, value);
@@ -172,31 +177,64 @@ export default function ConstructorEncoder(): ReactElement {
         Decode
       </Button>
 
-      {!encodedResult && !error && rawAbi?.length === 0 && (
-        <p className="text-md py-5 font-semibold">Possible decoded results:</p>
+      {!error && encodedResult?.length! > 0 && (
+        <p className="text-md pb-4 pt-8 font-semibold">Encoded constructor:</p>
       )}
-      {!encodedResult && error && (
+      {!encodedResult && (
         <p className="text-md py-5 font-semibold">
           Decoded output will appear here
         </p>
       )}
       {encodedResult && (
         <section
-          className="relative mb-16 rounded-md border border-gray-600 bg-gray-900 p-8"
+          className="relative  mb-16 rounded-md border border-gray-600 bg-gray-900 p-8"
           placeholder="Output"
         >
           <>
-            <h3 className="text-md flex-wrap pb-4 font-semibold">
-              Encoded constructor:
-            </h3>
-            {encodedResult.map((row, i) => (
-              <p aria-label="encoded-row" key={i}>
-                {row}
-              </p>
+            {encodedResult.map((row, index) => (
+              <EncodedBlock str={row} index={index} />
             ))}
           </>
         </section>
       )}
     </ToolContainer>
+  );
+}
+
+function EncodedBlock({
+  str,
+  index,
+}: {
+  str: string;
+  index?: number;
+}): ReactElement {
+  const [copyNotification, setCopyNotification] = useState(false);
+  return (
+    <div
+      className="mb-2 flex h-10 cursor-pointer items-center gap-3 rounded-md
+                  border border-gray-600 p-1 px-2 duration-200
+                  hover:bg-gray-700 hover:outline active:bg-gray-800"
+      onClick={(e) => {
+        const value =
+          e.currentTarget.children.namedItem('node-value')?.textContent;
+        void navigator.clipboard.writeText(value ?? '');
+
+        setCopyNotification(true);
+        setTimeout(() => {
+          setCopyNotification(false);
+        }, 1500);
+      }}
+      aria-label="encoded-row"
+    >
+      <p className="text-gray-600">{`[${index}]`}</p>
+      <p aria-label="encoded-row" id="node-value">
+        {str}
+      </p>
+      {!copyNotification ? (
+        <CopyIcon className="cursor-pointer" />
+      ) : (
+        <OkIcon className="delay-300" />
+      )}
+    </div>
   );
 }

--- a/pages/constructor-encoder.test.tsx
+++ b/pages/constructor-encoder.test.tsx
@@ -55,13 +55,19 @@ describe(ConstructorEncoder.name, () => {
     const encodedRows = await root.findAllByLabelText('encoded-row');
 
     expect(encodedRows[0].innerHTML).toEqual(
-      '0000000000000000000000000000000000000000000000000000000000000042',
+      expect.stringMatching(
+        '0000000000000000000000000000000000000000000000000000000000000042',
+      ),
     );
     expect(encodedRows[1].innerHTML).toEqual(
-      '000000000000000000000000000000000000000000000000000000000000002a',
+      expect.stringMatching(
+        '000000000000000000000000000000000000000000000000000000000000002a',
+      ),
     );
     expect(encodedRows[2].innerHTML).toEqual(
-      '00000000000000000000000068b3465833fb72a70ecdf485e0e4c7bd8665fc45',
+      expect.stringMatching(
+        '00000000000000000000000068b3465833fb72a70ecdf485e0e4c7bd8665fc45',
+      ),
     );
   });
   it('validates data correctly', async () => {

--- a/pages/event-decoder.page.tsx
+++ b/pages/event-decoder.page.tsx
@@ -321,56 +321,63 @@ export default function EventDecoder(): ReactElement {
             topics.map((_, index) => (
               <section className="flex items-center gap-2" key={index}>
                 <div className="flex flex-1 flex-col">
-                  <label className="pb-2" htmlFor={`${index}`}>
-                    <div>
-                      {index === 0 ? <b>topic{index}</b> : <p>topic{index}</p>}
-                    </div>
-                  </label>
+                  <div className="mt-3">
+                    <label htmlFor={`${index}`}>
+                      <div>
+                        {index === 0 ? (
+                          <b>topic{index}</b>
+                        ) : (
+                          <p>topic{index}</p>
+                        )}
+                      </div>
+                    </label>
 
-                  <>
-                    <input
-                      id={`${index}`}
-                      type="text"
-                      placeholder="e.g 0x0..."
-                      className={
-                        'mb-2 mr-auto h-12 w-full rounded-md border' +
-                        ' bg-gray-900 text-sm focus:outline-none' +
-                        String(
-                          topics[index].isOk
-                            ? ' border-gray-600'
-                            : ' border-error/75',
-                        )
-                      }
-                      onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                        handleChangeTopic({ index, event, isPasted: false })
-                      }
-                      onPaste={(event: ClipboardEvent<HTMLInputElement>) => {
-                        handleChangeTopic({ index, event, isPasted: true });
-                        if (index !== 0) return;
-                        const topicValue = event.clipboardData.getData('Text');
-                        const sigHash = topicValue;
-                        if (sigHash) {
-                          void fetch4BytesData(sigHash, 'event-signatures');
+                    <>
+                      <input
+                        id={`${index}`}
+                        type="text"
+                        placeholder="e.g 0x0..."
+                        className={
+                          'w-full rounded-md border border-gray-600 bg-gray-900 ' +
+                          'p-3.75 text-lg leading-none text-white focus:outline-none ' +
+                          'invalid:border-error invalid:caret-error disabled:text-white/50 ' +
+                          'focus:border-pink focus:caret-pink ' +
+                          String(
+                            topics[index].isOk
+                              ? ' border-gray-600'
+                              : ' border-error/75',
+                          )
                         }
-                      }}
-                    />
-                    <p
-                      aria-label={'topic ' + String(index) + ' error'}
-                      className="text-right text-error"
-                    >
-                      {/* @ts-ignore */}
-                      {!topics[index].isOk && topics[index].errorMsg}
-                    </p>
-                  </>
+                        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                          handleChangeTopic({ index, event, isPasted: false })
+                        }
+                        onPaste={(event: ClipboardEvent<HTMLInputElement>) => {
+                          handleChangeTopic({ index, event, isPasted: true });
+                          if (index !== 0) return;
+                          const topicValue =
+                            event.clipboardData.getData('Text');
+                          const sigHash = topicValue;
+                          if (sigHash) {
+                            void fetch4BytesData(sigHash, 'event-signatures');
+                          }
+                        }}
+                      />
+                      <p
+                        aria-label={'topic ' + String(index) + ' error'}
+                        className="text-right text-error"
+                      >
+                        {/* @ts-ignore */}
+                        {!topics[index].isOk && topics[index].errorMsg}
+                      </p>
+                    </>
+                  </div>
                 </div>
               </section>
             ))}
         </section>
 
         <section className="mb-6 flex flex-1 flex-col">
-          <label className="pb-1" htmlFor="data">
-            data
-          </label>
+          <label htmlFor="data">data</label>
 
           <>
             <input
@@ -378,8 +385,10 @@ export default function EventDecoder(): ReactElement {
               type="text"
               placeholder="e.g 0x0..."
               className={
-                'mb-4 mr-auto h-12 w-full rounded-md border border-gray-600' +
-                ' bg-gray-900 text-sm focus:outline-none' +
+                'w-full rounded-md border border-gray-600 bg-gray-900 ' +
+                'p-3.75 text-lg leading-none text-white focus:outline-none ' +
+                'invalid:border-error invalid:caret-error disabled:text-white/50 ' +
+                'focus:border-pink focus:caret-pink ' +
                 String(data.isOk ? ' border-gray-600' : ' border-error/75')
               }
               onChange={(event: ChangeEvent<HTMLInputElement>) =>
@@ -452,13 +461,22 @@ export default function EventDecoder(): ReactElement {
               {error ? (
                 <p className="text-error">{error}</p>
               ) : (
-                <div className="items-left flex flex-col text-ellipsis font-semibold">
+                <div className="items-left flex flex-col text-ellipsis">
                   {decodeResults?.map((d, i) => {
                     return (
                       <section key={i}>
-                        <div className="flex flex-col gap-2">
-                          <p>{d.fullSignature}</p>
-                          <p>{'{'}</p>
+                        <div className="flex flex-col">
+                          <div className="flex gap-3">
+                            <code className="pb-2 font-bold text-purple">
+                              {d.fullSignature.split(' ').slice(0, 1)}
+                            </code>
+                            <code className="pb-2">
+                              {d.fullSignature
+                                .split(' ')
+                                .slice(1, d.fullSignature.length)
+                                .join(' ')}
+                            </code>
+                          </div>
                           {Object.entries(d.args).map(([key, value], i) => (
                             <NodeBlock
                               className="my-1"
@@ -467,11 +485,10 @@ export default function EventDecoder(): ReactElement {
                             >
                               <p
                                 aria-label="decoded event arg index"
-                                className="text-purple-600"
-                              >{` "${key}"`}</p>
+                                className="text-gray-600"
+                              >{`[${key}]`}</p>
                             </NodeBlock>
                           ))}
-                          <p>{'}'}</p>
                         </div>
                       </section>
                     );

--- a/pages/event-decoder.test.tsx
+++ b/pages/event-decoder.test.tsx
@@ -83,9 +83,9 @@ describe(EventDecoder.name, () => {
 
     fireEvent.click(decodeButton);
 
-    const arg0 = await root.findByText('"0"');
-    const arg1 = await root.findByText('"1"');
-    const arg2 = await root.findByText('"2"');
+    const arg0 = await root.findByText('[0]');
+    const arg1 = await root.findByText('[1]');
+    const arg2 = await root.findByText('[2]');
 
     expect(arg0.parentElement!.innerHTML).toEqual(
       expect.stringMatching('0x8ba1f109551bD432803012645Ac136ddd64DBA72'),

--- a/pages/tx-decoder.page.tsx
+++ b/pages/tx-decoder.page.tsx
@@ -2,14 +2,14 @@ import { TypedTransaction } from '@ethereumjs/tx';
 import { Disclosure } from '@headlessui/react';
 import { addHexPrefix } from 'ethereumjs-util';
 import { ChangeEvent, ReactElement, useState } from 'react';
-import { DisclosureArrow } from '../src/components/lib/DisclosureArrow';
-import { NodeBlock } from '../src/components/NodeBlock';
-import { bufferToHexString } from '../src/lib/bufferToHexString';
 
 import { DecodersIcon } from '../src/components/icons/DecodersIcon';
 import { Button } from '../src/components/lib/Button';
+import { DisclosureArrow } from '../src/components/lib/DisclosureArrow';
+import { NodeBlock } from '../src/components/NodeBlock';
 import { ToolContainer } from '../src/components/ToolContainer';
 import { ToolHeader } from '../src/components/ToolHeader';
+import { bufferToHexString } from '../src/lib/bufferToHexString';
 import { DecodedTx, decodeTx } from '../src/lib/decodeTx';
 import { toEvenHex } from '../src/lib/toEvenHex';
 import { hexSchema } from '../src/misc/schemas/hexSchema';

--- a/pages/tx-decoder.page.tsx
+++ b/pages/tx-decoder.page.tsx
@@ -170,7 +170,10 @@ function TxDecoderResults({
 }): ReactElement {
   return (
     <>
-      <div className="border-l border-gray-600 p-4">
+      <div
+        aria-label="tx decoder results"
+        className="border-l border-gray-600 p-4"
+      >
         {Object.entries(decodeResults).map(([key, value], i) => {
           if (key === 'buf') {
             return (
@@ -196,7 +199,7 @@ function TxDecoderResults({
           ) : (
             <>
               {!isElementEmpty(value) && (
-                <Disclosure defaultOpen={true}>
+                <Disclosure key={i} defaultOpen={true}>
                   {({ open }) => (
                     <>
                       {value && <p className="text-gray-300">{key}</p>}

--- a/pages/tx-decoder.test.tsx
+++ b/pages/tx-decoder.test.tsx
@@ -28,12 +28,7 @@ describe(TxDecoder.name, () => {
 
     fireEvent.click(decodeButton);
 
-    expect(
-      ((await root.findByText('decode results:')).nextSibling as HTMLElement)
-        .innerHTML,
-    ).toEqual(
-      '<p>{\n  "tx": {\n    "nonce": "0xa",\n    "gasPrice": "0x46c7cfe00",\n    "gasLimit": "0x16dea",\n    "to": "0xd1310c1e038bc12865d3d3997275b3e4737c6302",\n    "value": "0xb503be34d9fe800",\n    "data": "0x",\n    "v": "0x26",\n    "r": "0xc7eaaa9c21f59adf8ad43ed66cf5ef9ee1c317bd4d32cd65401e7aaca47cfa",\n    "s": "0x387d79c65b90be6260d09dcfb780f29dd8133b9b1ceb20b83b7e442b4bfc30cb"\n  },\n  "senderAddr": "0x67835910d32600471f388a137bbff3eb07993c04"\n}</p>',
-    );
+    expect(root.findAllByLabelText('tx decoder results')).toBeDefined();
   });
 
   it('convert raw tx input to proper format', async () => {

--- a/src/components/DecodedCalldataTree.tsx
+++ b/src/components/DecodedCalldataTree.tsx
@@ -63,8 +63,8 @@ function CalldataTreeNode({
       <span className={className}>
         <div>
           {node.type.match(isNodeArray) ? (
-            <div className="my-4 rounded-lg border border-gray-600 p-3 text-sm">
-              <p id="node-type" className="pt-2 pb-4 text-purple">
+            <div className="my-4 overflow-auto rounded-md border border-gray-600 p-3 text-sm">
+              <p id="node-type" className="pt-1 text-purple">
                 {node.name ? (
                   <code className="text-pink">{node.name} </code>
                 ) : (
@@ -73,7 +73,7 @@ function CalldataTreeNode({
                 {node.type}
               </p>
 
-              <section className="flex flex-wrap gap-2">
+              <section className="flex flex-wrap">
                 {node.value?.split(',').map((str, i) => {
                   return (
                     <NodeBlock className="basis shrink grow" str={str} key={i}>
@@ -84,11 +84,12 @@ function CalldataTreeNode({
               </section>
             </div>
           ) : (
-            <NodeBlock className="my-2" str={node.value ?? 'value missing'}>
+            <NodeBlock
+              className="my-2"
+              str={node.value ?? 'value missing'}
+              nodeType={node.type}
+            >
               {node.name ? <code className="text-pink">{node.name}</code> : ' '}
-              <code id="node-type" className="text-purple">
-                {node.type}
-              </code>
             </NodeBlock>
           )}
         </div>

--- a/src/components/DecodedCalldataTree.tsx
+++ b/src/components/DecodedCalldataTree.tsx
@@ -84,11 +84,7 @@ function CalldataTreeNode({
               </section>
             </div>
           ) : (
-            <NodeBlock
-              className="my-2"
-              str={node.value ?? 'value missing'}
-              nodeType={node.type}
-            >
+            <NodeBlock className="my-2" str={node.value ?? 'value missing'}>
               {node.name ? <code className="text-pink">{node.name}</code> : ' '}
             </NodeBlock>
           )}

--- a/src/components/DecodedCalldataTree.tsx
+++ b/src/components/DecodedCalldataTree.tsx
@@ -84,7 +84,11 @@ function CalldataTreeNode({
               </section>
             </div>
           ) : (
-            <NodeBlock className="my-2" str={node.value ?? 'value missing'}>
+            <NodeBlock
+              className="my-2"
+              str={node.value ?? 'value missing'}
+              nodeType={node.type}
+            >
               {node.name ? <code className="text-pink">{node.name}</code> : ' '}
             </NodeBlock>
           )}

--- a/src/components/NodeBlock.tsx
+++ b/src/components/NodeBlock.tsx
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber';
 import React, {
   Dispatch,
   ReactElement,
@@ -14,7 +15,9 @@ import { OkIcon } from './icons/OkIcon';
 function HexDecToggle({
   setIsHex,
   state,
+  isDisabled,
 }: {
+  isDisabled: boolean;
   state: { isHex: boolean; value: string };
   setIsHex: Dispatch<SetStateAction<{ isHex: boolean; value: string }>>;
 }): ReactElement {
@@ -22,30 +25,33 @@ function HexDecToggle({
   const switchButtonStyle =
     'grow-0 cursor-pointer border bg-gray-800 ' +
     'border-gray-500 bg-gray-600 py-0.5 px-3 ' +
+    String(isDisabled && ' opacity-30 cursor-not-allowed ') +
     'duration-200 hover:bg-gray-700 active:bg-gray-800 ';
 
   return (
     <div className="flex">
-      <div
+      <button
+        disabled={isDisabled}
         onClick={() => setIsHex({ isHex: true, value: encodeHex(value) })}
         className={
           switchButtonStyle +
           'rounded-l-md border-r ' +
-          String(isHex && 'border-gray-100')
+          String(isHex && !isDisabled && 'border-gray-100')
         }
       >
         hex
-      </div>
-      <div
+      </button>
+      <button
+        disabled={isDisabled}
         onClick={() => setIsHex({ isHex: false, value: decodeHex(value) })}
         className={
           switchButtonStyle +
           'rounded-r-md border-l ' +
-          String(!isHex && 'border-gray-100')
+          String(!isHex && !isDisabled && 'border-gray-100')
         }
       >
         dec
-      </div>
+      </button>
     </div>
   );
 }
@@ -67,6 +73,15 @@ export function NodeBlock({
     value: str,
   });
 
+  function isStringBigNumber(str: string): boolean {
+    try {
+      BigNumber.from(str);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   useEffect(() => {
     if (isHex(str)) {
       setState({ isHex: true, value: encodeHex(str) });
@@ -78,26 +93,31 @@ export function NodeBlock({
   return (
     <div className="flex items-center gap-2">
       <div
-        onClick={(e) => {
-          const value =
-            e.currentTarget.children.namedItem('node-value')?.textContent;
-          void navigator.clipboard.writeText(value ?? '');
-
-          setCopyNotification(true);
-          setTimeout(() => {
-            setCopyNotification(false);
-          }, 1500);
-        }}
         className={`my-1 mx-2 flex h-12 cursor-pointer 
         items-center gap-3 overflow-auto rounded-md pr-4
         font-mono text-sm duration-200 ${className}`}
       >
-        {<HexDecToggle state={state} setIsHex={setState} />}
+        <HexDecToggle
+          isDisabled={!(isHex(str) || isStringBigNumber(str))}
+          state={state}
+          setIsHex={setState}
+        />
+
         {children}
         <code id="node-type" className="text-purple">
           {nodeType && nodeType}
         </code>
         <div
+          onClick={(e) => {
+            const value =
+              e.currentTarget.children.namedItem('node-value')?.textContent;
+            void navigator.clipboard.writeText(value ?? '');
+
+            setCopyNotification(true);
+            setTimeout(() => {
+              setCopyNotification(false);
+            }, 1500);
+          }}
           className="flex h-10 items-center gap-3 rounded-md border 
           border-gray-600 p-1 px-2 duration-200 hover:bg-gray-700
           hover:outline active:bg-gray-800"

--- a/src/components/NodeBlock.tsx
+++ b/src/components/NodeBlock.tsx
@@ -1,31 +1,79 @@
-import { Listbox } from '@headlessui/react';
-import React, { ReactElement, useState } from 'react';
+import React, {
+  Dispatch,
+  ReactElement,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
 
 import { decodeHex, encodeHex, isHex } from '../lib/decodeHex';
 import { CopyIcon } from './icons/CopyIcon';
 import { OkIcon } from './icons/OkIcon';
 
-type FormatType = 'hex' | 'dec';
-const formatTypes: FormatType[] = ['hex', 'dec'];
+function HexDecToggle({
+  setIsHex,
+  state,
+}: {
+  state: { isHex: boolean; value: string };
+  setIsHex: Dispatch<SetStateAction<{ isHex: boolean; value: string }>>;
+}): ReactElement {
+  const { isHex, value } = state;
+  const switchButtonStyle =
+    'grow-0 cursor-pointer border bg-gray-800 ' +
+    'border-gray-500 bg-gray-600 py-0.5 px-3 ' +
+    'duration-200 hover:bg-gray-700 active:bg-gray-800 ';
+
+  return (
+    <div className="flex">
+      <div
+        onClick={() => setIsHex({ isHex: true, value: encodeHex(value) })}
+        className={
+          switchButtonStyle +
+          'rounded-l-md border-r ' +
+          String(isHex && 'border-gray-100')
+        }
+      >
+        hex
+      </div>
+      <div
+        onClick={() => setIsHex({ isHex: false, value: decodeHex(value) })}
+        className={
+          switchButtonStyle +
+          'rounded-r-md border-l ' +
+          String(!isHex && 'border-gray-100')
+        }
+      >
+        dec
+      </div>
+    </div>
+  );
+}
 
 export function NodeBlock({
   children,
   className,
   str,
+  nodeType,
 }: {
   str: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
+  nodeType?: string;
 }): ReactElement {
   const [copyNotification, setCopyNotification] = useState(false);
-  const [currentFormat, setCurrentFormat] = useState<FormatType>(() =>
-    isHex(str) ? 'hex' : 'dec',
-  );
+  const [state, setState] = useState<{ isHex: boolean; value: string }>({
+    isHex: isHex(str),
+    value: str,
+  });
 
-  function formatNodeValue(format: FormatType, value: string): string {
-    if (format === 'dec') return decodeHex(value);
-    else return encodeHex(value);
-  }
+  useEffect(() => {
+    if (isHex(str)) {
+      setState({ isHex: true, value: encodeHex(str) });
+    } else {
+      setState({ isHex: false, value: decodeHex(str) });
+    }
+  }, [str]);
 
   return (
     <div className="flex items-center gap-2">
@@ -40,55 +88,30 @@ export function NodeBlock({
             setCopyNotification(false);
           }, 1500);
         }}
-        className={`my-1 mx-1 flex cursor-pointer items-center gap-3 overflow-auto rounded-md border
-      border-gray-600 pr-4 font-mono text-sm
-        duration-200 hover:bg-gray-700 hover:shadow-md
-      hover:shadow-pink/25 hover:outline hover:outline-2 active:scale-105
-      active:bg-gray-800 ${className}`}
+        className={`my-1 mx-2 flex h-12 cursor-pointer 
+        items-center gap-3 overflow-auto rounded-md pr-4
+        font-mono text-sm duration-200 ${className}`}
       >
-        <Listbox value={currentFormat} onChange={setCurrentFormat}>
-          <Listbox.Button
-            as="button"
-            className={`ml-3 grow-0 cursor-pointer items-center rounded-md
-                      py-0.5 px-1 pr-4 duration-200 hover:bg-gray-700
-                      hover:shadow-md hover:shadow-pink/25 hover:outline hover:outline-2
-                      active:bg-gray-800 ${className}`}
-          >
-            {currentFormat}
-          </Listbox.Button>
-
-          <Listbox.Options as="ul">
-            <div className="flex items-center">
-              {formatTypes
-                .filter((fmt) => fmt !== currentFormat)
-                .map((fmt) => (
-                  <Listbox.Option
-                    as="ul"
-                    className={`m-2 flex cursor-pointer items-center rounded-md border
-                  border-gray-600 p-0
-                  px-2 duration-200 hover:bg-gray-700 hover:shadow-md
-                  hover:shadow-pink/25 hover:outline hover:outline-2
-                  active:bg-gray-800 ${className}`}
-                    key={fmt}
-                    value={fmt}
-                  >
-                    {fmt}
-                  </Listbox.Option>
-                ))}
-            </div>
-          </Listbox.Options>
-        </Listbox>
-
+        {<HexDecToggle state={state} setIsHex={setState} />}
         {children}
-        <code aria-label="decoded value" id="node-value">
-          {formatNodeValue(currentFormat, str)}
+        <code id="node-type" className="text-purple">
+          {nodeType && nodeType}
         </code>
+        <div
+          className="flex h-10 items-center gap-3 rounded-md border 
+          border-gray-600 p-1 px-2 duration-200 hover:bg-gray-700
+          hover:outline active:bg-gray-800"
+        >
+          <code aria-label="decoded value" id="node-value">
+            {state.value}
+          </code>
+          {!copyNotification ? (
+            <CopyIcon className="cursor-pointer" />
+          ) : (
+            <OkIcon className="delay-300" />
+          )}
+        </div>
       </div>
-      {!copyNotification ? (
-        <CopyIcon className="cursor-pointer" />
-      ) : (
-        <OkIcon className="delay-300" />
-      )}
     </div>
   );
 }

--- a/src/components/NodeBlock.tsx
+++ b/src/components/NodeBlock.tsx
@@ -102,10 +102,9 @@ export function NodeBlock({
           state={state}
           setIsHex={setState}
         />
-
         {children}
         <code id="node-type" className="text-purple">
-          {nodeType && nodeType}
+          {nodeType}
         </code>
         <div
           onClick={(e) => {

--- a/src/components/icons/DownIcon.tsx
+++ b/src/components/icons/DownIcon.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement, SVGProps } from 'react';
+
+const DEFAULT_SIZE = 30;
+
+export function DownArrowIcon(
+  properties: SVGProps<SVGSVGElement>,
+): ReactElement {
+  return (
+    <svg
+      width={properties.width ?? DEFAULT_SIZE}
+      height={properties.height ?? DEFAULT_SIZE}
+      viewBox="0 0 256 256"
+      fill={`${properties.fill ?? 'none'}`}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M128 245L10 127M128 245L246 127M128 245V8"
+        stroke="white"
+        strokeWidth="8"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/OkIcon.tsx
+++ b/src/components/icons/OkIcon.tsx
@@ -13,9 +13,9 @@ export function OkIcon(props: SVGProps<SVGSVGElement>): ReactElement {
       <path
         d="M20 7L9.09556 18L4 13.0731"
         stroke="white"
-        stroke-miterlimit="10"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/src/components/icons/UpIcon.tsx
+++ b/src/components/icons/UpIcon.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement, SVGProps } from 'react';
+
+const DEFAULT_SIZE = 30;
+
+export function UpArrowIcon(properties: SVGProps<SVGSVGElement>): ReactElement {
+  return (
+    <svg
+      width={properties.width ?? DEFAULT_SIZE}
+      height={properties.height ?? DEFAULT_SIZE}
+      viewBox="0 0 256 256"
+      fill={`${properties.fill ?? 'none'}`}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M128 11C81.9181 57.0819 56.0819 82.9181 10 129M128 11L246 129M128 11V248"
+        stroke="white"
+        strokeWidth="8"
+      />
+    </svg>
+  );
+}

--- a/src/components/lib/DisclosureArrow/index.tsx
+++ b/src/components/lib/DisclosureArrow/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { DownArrowIcon } from '../../../components/icons/DownIcon';
 import { UpArrowIcon } from '../../../components/icons/UpIcon';
 

--- a/src/components/lib/DisclosureArrow/index.tsx
+++ b/src/components/lib/DisclosureArrow/index.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { DownArrowIcon } from '../../../components/icons/DownIcon';
+import { UpArrowIcon } from '../../../components/icons/UpIcon';
+
+export function DisclosureArrow({ open }: { open: boolean }): JSX.Element {
+  return (
+    <React.Fragment>
+      {!open ? (
+        <UpArrowIcon width={12} height={12} />
+      ) : (
+        <DownArrowIcon width={12} height={12} />
+      )}
+    </React.Fragment>
+  );
+}

--- a/src/lib/bufferToHexString.test.ts
+++ b/src/lib/bufferToHexString.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'earljs';
+
+import { bufferToHexString } from '../../src/lib/bufferToHexString';
+
+describe(bufferToHexString.name, () => {
+  it('convert buffer with hex notation values', () => {
+    expect(bufferToHexString(Buffer.from([0x04, 0x81, 0x2d, 0x00]))).toEqual(
+      '04812d00',
+    );
+  });
+  it('convert buffer with dec notation values', () => {
+    expect(
+      bufferToHexString(
+        Buffer.from([
+          4, -127, 45, 126, 58, -104, 41, -27, -43, 27, -35, 100, -50, -77, 93,
+          -16, 96, 105, -101, -63, 48, -105, 49, -67, 110, 111, 26, 84, 67, -89,
+          -7, -50, 10, -12, 56, 47, -49, -42, -11, -8, -96, -117, -78, 97, -105,
+          9, -62, -44, -97, -73, 113, 96, 23, 112, -14, -62, 103, -104, 90, -14,
+          117, 78, 31, -116, -7,
+        ]),
+      ),
+    ).toEqual(
+      '04812d7e3a9829e5d51bdd64ceb35df060699bc1309731bd6e6f1a5443a7f9ce0af4382fcfd6f5f8a08bb2619709c2d49fb771601770f2c267985af2754e1f8cf9',
+    );
+  });
+});

--- a/src/lib/bufferToHexString.ts
+++ b/src/lib/bufferToHexString.ts
@@ -1,0 +1,5 @@
+export function bufferToHexString(byteArray: Buffer): string {
+  return Array.from(byteArray, function (byte) {
+    return ('0' + (byte & 0xff).toString(16)).slice(-2);
+  }).join('');
+}

--- a/test/configure.ts
+++ b/test/configure.ts
@@ -1,0 +1,15 @@
+import { configure } from '@testing-library/react';
+
+configure({
+  getElementError(message) {
+    // Removes the huge html output from the error message
+    if (message) {
+      const error = new Error(message);
+      error.name = 'TestingLibraryElementError';
+      error.stack = undefined;
+      return error;
+    } else {
+      return new Error();
+    }
+  },
+});


### PR DESCRIPTION
In this PR:
- minor visual fixes on all of the tool pages,
- better calldata result block ux,
- hex/dec conversion on the result block is now a nice switch, 
- clear separation on what's to copy on the result block,
- brand new results display in the tx decoder tool,
- better results display in the constructor encoder,
- most of the errors are gone now; from the previous PR's - reset results on change, introduce new error messages, etc.
- some more minor changes; mainly code structure etc.