### PR TITLE
Reverse 4byte results to show older signatures first

### DIFF
--- a/src/lib/decodeBySigHash.ts
+++ b/src/lib/decodeBySigHash.ts
@@ -62,9 +62,9 @@ async function fetch4Bytes(
     return cached;
   }
   try {
-    const { results } = await safeFetch<FourBytesResponse>(
-      `${urlTo(hexSigType)}${hexSig}`,
-    );
+    const results = (
+      await safeFetch<FourBytesResponse>(`${urlTo(hexSigType)}${hexSig}`)
+    ).results.reverse();
     bytes4Cache[hexSigType][hexSig] = results;
     result = results;
   } catch (error) {


### PR DESCRIPTION
Usually, older signatures are what people are looking for. Now, some bad actors are trying to find hash collisions with well-known signatures to advertise their telegram channels, so they should not be shown above older signatures.

Before:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/29802592/192749487-b790c29b-46ba-46f9-b57c-628553801a80.png">
After:
<img width="659" alt="image" src="https://user-images.githubusercontent.com/29802592/192749544-60c3900b-93ba-4325-a021-af9a840d09bb.png">
